### PR TITLE
Add geometric scoring to decoder

### DIFF
--- a/nets/actor_network.py
+++ b/nets/actor_network.py
@@ -90,6 +90,8 @@ class Actor(nn.Module):
     def forward(self, problem, batch, x_in, solution, context, context2,last_action, fixed_action = None, require_entropy = False, to_critic = False, only_critic  = False):
         # the embedded input x
         bs, gs, in_d = x_in.size()
+        coords = batch['coordinates']
+        edge_len = torch.cdist(coords, coords, p=2)
         
         if problem.NAME == 'cvrp':
             
@@ -119,6 +121,7 @@ class Actor(nn.Module):
                                                context2,
                                                visited_time,
                                                last_action,
+                                               edge_len,
                                                fixed_action = fixed_action,
                                                require_entropy = require_entropy)
         


### PR DESCRIPTION
## Summary
- compute pairwise coordinate distance matrix in `Actor.forward`
- extend `kopt_Decoder` with optional `edge_len` argument
- include geometric weighting in decoder score
- keep configurable `geo_weight` parameter

## Testing
- `python -m py_compile nets/actor_network.py nets/graph_layers.py agent/ppo.py`

------
https://chatgpt.com/codex/tasks/task_e_68540264c0008328b1bf06d7276a6038