### PR TITLE
Add geo_weight logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can resume a training by adding the --resume option:
 --resume '{add last saved checkpoint(model) to resume here}'
 ```
 The Tensorboard logs will be saved to folder "logs" and the trained model (checkpoint) will be saved to folder "outputs".
+Tensorboard now records the decoder's `geo_weight` as `train/geo_weight` for each mini-step.
 
 ## Inference
 Load the model and specify the following hyper-parameters for inference:

--- a/agent/ppo.py
+++ b/agent/ppo.py
@@ -312,7 +312,9 @@ def train(rank, problem, agent, val_dataset, tb_logger):
                         weights
                         )
             step += 1
-            
+            if rank == 0:
+                pbar.set_postfix(geo_weight=f"{agent.actor.decoder.geo_weight.item():.4f}")
+
         pbar.close()
         # save new model after one epoch  
         if rank == 0 and not opts.distributed: 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -46,6 +46,7 @@ def log_to_tb_train(tb_logger, agent, Reward, ratios, bl_val_detached, total_cos
     tb_logger.log_value('train/init_cost', initial_cost.mean(), mini_step)
     tb_logger.log_value('train/c_cost_logger', c_cost_logger.item(), mini_step)
     tb_logger.log_value('train/weights', weights, mini_step)
+    tb_logger.log_value('train/geo_weight', agent.actor.decoder.geo_weight.item(), mini_step)
     tb_logger.log_value('train/entropy', entropy.mean().item(), mini_step)
     tb_logger.log_value('train/approx_kl_divergence', approx_kl_divergence.item(), mini_step)
     tb_logger.log_histogram('train/bl_val',bl_val_detached.cpu(),mini_step)


### PR DESCRIPTION
## Summary
- log decoder geo_weight to Tensorboard
- display geo_weight progress during training
- mention geo_weight metric in README

## Testing
- `python -m py_compile agent/ppo.py utils/logger.py`

------
https://chatgpt.com/codex/tasks/task_e_68541ac609bc8328a74069cecca87a5f