### PR TITLE
Add configurable RTDL update interval

### DIFF
--- a/options.py
+++ b/options.py
@@ -30,6 +30,7 @@ def get_options(args=None):
     parser.add_argument('--wo_feature1', action='store_true') # to remove VI featrues
     parser.add_argument('--wo_feature3', action='store_true')  # to remove ES featrues
     parser.add_argument('--wo_RTDL', action='store_true', help='Disable RTDL additional feature')
+    parser.add_argument('--update_RTD', type=int, default=1, help='Steps between RTDL weight updates')
     parser.add_argument('--wo_MDP', action='store_true', default=True) # always True (disabled function)
     
     ### resume and load models


### PR DESCRIPTION
## Summary
- allow setting how often RTDL weights are recomputed
- compute RTDL features outside of actor forward pass when desired
- support storing RTDL features in training memory

## Testing
- `python -m py_compile options.py nets/actor_network.py agent/ppo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6f36192c83288846762f810be350