### PR TITLE
Add optional 1-tree distance optimization for RTDL MST

### DIFF
--- a/agent/ppo.py
+++ b/agent/ppo.py
@@ -62,7 +62,8 @@ class PPO:
             with_feature3 = not opts.wo_feature3,
             with_simpleMDP = opts.wo_MDP,
             with_RTDL = not opts.wo_RTDL,
-            geo_weight = opts.geo_weight
+            geo_weight = opts.geo_weight,
+            use_1tree_opt = opts.use_1tree_opt
         )
         
         if not opts.eval_only:

--- a/nets/actor_network.py
+++ b/nets/actor_network.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn
 import torch.multiprocessing as mp
 from nets.graph_layers import MultiHeadEncoder, EmbeddingNet, MultiHeadPosCompat, kopt_Decoder
-from utils import masked_dist_matrix
+from utils import masked_dist_matrix, optimize_D_1tree
 from RTD_Lite_TSP import RTD_Lite, prim_algo
 
 def _run_rtd_lite(args):
@@ -36,7 +36,8 @@ class Actor(nn.Module):
                  with_feature3,
                  with_simpleMDP,
                  with_RTDL,
-                 geo_weight=5.0
+                 geo_weight=5.0,
+                 use_1tree_opt=False
                  ):
         super(Actor, self).__init__()
 
@@ -54,6 +55,7 @@ class Actor(nn.Module):
         self.with_feature3 = with_feature3
         self.with_simpleMDP = with_simpleMDP
         self.with_RTDL = with_RTDL
+        self.use_1tree_opt = use_1tree_opt
         
         if problem_name == 'tsp':
             self.node_dim = 2
@@ -104,9 +106,14 @@ class Actor(nn.Module):
         edge_len = torch.cdist(coords, coords, p=2)
         mst_list = []
         for i in range(len(edge_len)):
-            _, edge_idx, edge_w = prim_algo(edge_len[i].cpu())
-            edge_idx = edge_idx[edge_w.argsort()]
-            edge_w = edge_w[edge_w.argsort()]
+            dist = edge_len[i].cpu().numpy()
+            if self.use_1tree_opt:
+                _, dist = optimize_D_1tree(dist, lr=1e-3)
+            _, edge_idx, _ = prim_algo(torch.tensor(dist, dtype=torch.float32))
+            edge_w = edge_len[i][edge_idx[:, 0], edge_idx[:, 1]]
+            order = edge_w.argsort()
+            edge_idx = edge_idx[order.numpy()]
+            edge_w = edge_w[order]
             mst_list.append((edge_idx, edge_w))
         return mst_list
 

--- a/options.py
+++ b/options.py
@@ -31,6 +31,7 @@ def get_options(args=None):
     parser.add_argument('--wo_feature3', action='store_true')  # to remove ES featrues
     parser.add_argument('--wo_RTDL', action='store_true', help='Disable RTDL additional feature')
     parser.add_argument('--update_RTD', type=int, default=1, help='Steps between RTDL weight updates')
+    parser.add_argument('--use_1tree_opt', action='store_true', help='Optimize distance matrix before MST computation for RTDL')
     parser.add_argument('--wo_MDP', action='store_true', default=True) # always True (disabled function)
     
     ### resume and load models

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -2,6 +2,9 @@ import torch
 import math
 import numpy as np
 import random
+from collections import Counter
+from scipy.sparse.csgraph import minimum_spanning_tree
+from scipy.sparse import coo_matrix
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 def get_rotate_mat(theta_f: float) -> torch.Tensor:
@@ -91,5 +94,64 @@ def masked_dist_matrix(edges: torch.Tensor, distmatrix: torch.Tensor) -> torch.T
     masked[batch_idx, idx.unsqueeze(0).expand(bs, n), edges] = distmatrix[batch_idx, idx.unsqueeze(0).expand(bs, n), edges]
     masked[batch_idx, edges, idx.unsqueeze(0).expand(bs, n)] = distmatrix[batch_idx, edges, idx.unsqueeze(0).expand(bs, n)]
     return masked
+
+
+def optimize_D_1tree(Din, lr, n_iter=10 ** 5):
+    """Optimize distance matrix for 1-tree construction.
+
+    Parameters
+    ----------
+    Din : np.ndarray
+        Initial distance matrix.
+    lr : float
+        Learning rate for optimization.
+    n_iter : int, optional
+        Maximum number of iterations.
+
+    Returns
+    -------
+    tuple
+        (best_cnt, best_D) where best_D is the optimized matrix.
+    """
+
+    D = np.array(Din, dtype=float)
+
+    best_cnt = float("inf")
+    best_D = D.copy()
+    best_iter = 0
+
+    for iter_num in range(n_iter):
+        D1 = D[1:, 1:]
+        xsorted = sorted(enumerate(D[0]), key=lambda x: x[1])
+
+        mst = minimum_spanning_tree(D1)
+        mst_coo = coo_matrix(mst)
+        m = np.mean(mst_coo.data)
+
+        c = Counter()
+        for i in range(mst_coo.nnz):
+            c[mst_coo.row[i] + 1] += 1
+            c[mst_coo.col[i] + 1] += 1
+
+        c[xsorted[1][0]] += 1
+        c[xsorted[2][0]] += 1
+
+        cnt_deg_neq_2 = len([x for x in c.values() if x != 2])
+
+        if cnt_deg_neq_2 < best_cnt:
+            best_cnt = cnt_deg_neq_2
+            best_D = D.copy()
+            best_iter = iter_num
+
+        if iter_num - best_iter > 100:
+            return best_cnt, best_D
+
+        for v, degree in c.items():
+            D[:, v] += lr * m * (degree - 2)
+            D[v, :] += lr * m * (degree - 2)
+
+        np.fill_diagonal(D, 0)
+
+    return best_cnt, best_D
 
 


### PR DESCRIPTION
## Summary
- add optimize_D_1tree utility to refine distance matrices for MST
- support `--use_1tree_opt` flag to enable optimization during RTDL MST precomputation
- compute MST using optimized matrix while preserving original distances for model input