### PR TITLE
Add optional normalization for decoder geo distance

### DIFF
--- a/agent/ppo.py
+++ b/agent/ppo.py
@@ -63,7 +63,8 @@ class PPO:
             with_simpleMDP = opts.wo_MDP,
             with_RTDL = not opts.wo_RTDL,
             geo_weight = opts.geo_weight,
-            use_1tree_opt = opts.use_1tree_opt
+            use_1tree_opt = opts.use_1tree_opt,
+            normalize_curr_dist = not opts.no_curr_dist_norm
         )
         
         if not opts.eval_only:

--- a/nets/actor_network.py
+++ b/nets/actor_network.py
@@ -37,7 +37,8 @@ class Actor(nn.Module):
                  with_simpleMDP,
                  with_RTDL,
                  geo_weight=5.0,
-                 use_1tree_opt=False
+                 use_1tree_opt=False,
+                 normalize_curr_dist=True
                  ):
         super(Actor, self).__init__()
 
@@ -56,6 +57,7 @@ class Actor(nn.Module):
         self.with_simpleMDP = with_simpleMDP
         self.with_RTDL = with_RTDL
         self.use_1tree_opt = use_1tree_opt
+        self.normalize_curr_dist = normalize_curr_dist
         
         if problem_name == 'tsp':
             self.node_dim = 2
@@ -91,7 +93,8 @@ class Actor(nn.Module):
                                     with_RNN = self.with_RNN,
                                     with_feature3 = self.with_feature3,
                                     simpleMDP = self.with_simpleMDP,
-                                    geo_weight = geo_weight
+                                    geo_weight = geo_weight,
+                                    normalize_curr_dist = self.normalize_curr_dist
                                     )
 
         print('# params in Actor', self.get_parameter_number())

--- a/nets/graph_layers.py
+++ b/nets/graph_layers.py
@@ -311,7 +311,8 @@ class kopt_Decoder(nn.Module):
             with_RNN = True,
             with_feature3 = True,
             simpleMDP = False,
-            geo_weight = 5.0
+            geo_weight = 5.0,
+            normalize_curr_dist = True
     ):
         super(kopt_Decoder, self).__init__()
         self.n_heads = n_heads
@@ -322,6 +323,7 @@ class kopt_Decoder(nn.Module):
         self.with_RNN = with_RNN
         self.with_feature3 = with_feature3
         self.simpleMDP = simpleMDP
+        self.normalize_curr_dist = normalize_curr_dist
         # self.geo_weight = nn.Parameter(torch.tensor(float(geo_weight)))
         self.geo_weight = torch.tensor(geo_weight)
         print('simpleMDP: ', self.simpleMDP)
@@ -414,6 +416,11 @@ class kopt_Decoder(nn.Module):
                   # solution instead of the edge entering it from the previously
                   # selected node.
                   curr_dist = edge_len.gather(2, rec.unsqueeze(-1)).squeeze(-1)
+                  if self.normalize_curr_dist:
+                      min_val = curr_dist.min(dim=1, keepdim=True)[0]
+                      max_val = curr_dist.max(dim=1, keepdim=True)[0]
+                      denom = (max_val - min_val).clamp(min=1e-9)
+                      curr_dist = (curr_dist - min_val) / denom
                   result = result + self.geo_weight * curr_dist
                   # print("Sizes of vectors:","MU:",mu_term,"lambda:", lambda_term,"RTDL:", self.geo_weight * curr_dist, sep = "\n")
               

--- a/options.py
+++ b/options.py
@@ -77,6 +77,8 @@ def get_options(args=None):
                         help='Final value for geo_weight after annealing')
     parser.add_argument('--geo_weight_anneal_epochs', type=int, default=0,
                         help='Number of epochs over which to anneal geo_weight (0 disables annealing)')
+    parser.add_argument('--no_curr_dist_norm', action='store_true',
+                        help='Disable normalization of curr_dist before applying geo_weight')
     
     ### logs to tensorboard and screen
     parser.add_argument('--no_progress_bar', action='store_true', help='Disable progress bar')


### PR DESCRIPTION
## Summary
- Normalize RTDL edge weights via min-max before applying `geo_weight` in `kopt_Decoder`
- Add `--no_curr_dist_norm` flag to disable curr_dist normalization and plumb through PPO/Actor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2b0a69c048328b22f39be7b21aad7