### PR TITLE
Make geo_weight optionally trainable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ You can resume a training by adding the --resume option:
 ```
 The Tensorboard logs will be saved to folder "logs" and the trained model (checkpoint) will be saved to folder "outputs".
 Tensorboard now records the decoder's `geo_weight` as `train/geo_weight` for each mini-step.
+Use `--trainable_geo_weight` to make this weight learnable during training; omit the flag to keep it fixed.
 
 ## Inference
 Load the model and specify the following hyper-parameters for inference:

--- a/agent/ppo.py
+++ b/agent/ppo.py
@@ -63,6 +63,7 @@ class PPO:
             with_simpleMDP = opts.wo_MDP,
             with_RTDL = not opts.wo_RTDL,
             geo_weight = opts.geo_weight,
+            trainable_geo_weight = opts.trainable_geo_weight,
             use_1tree_opt = opts.use_1tree_opt
         )
         
@@ -284,7 +285,7 @@ def train(rank, problem, agent, val_dataset, tb_logger):
             else:
                 new_weight = opts.geo_weight_min
             decoder = agent.actor.module.decoder if hasattr(agent.actor, 'module') else agent.actor.decoder
-            decoder.geo_weight = torch.tensor(new_weight, device=decoder.geo_weight.device)
+            decoder.geo_weight.data.fill_(new_weight)
 
         # Training mode
         if rank == 0:

--- a/nets/actor_network.py
+++ b/nets/actor_network.py
@@ -37,6 +37,7 @@ class Actor(nn.Module):
                  with_simpleMDP,
                  with_RTDL,
                  geo_weight=5.0,
+                 trainable_geo_weight=False,
                  use_1tree_opt=False
                  ):
         super(Actor, self).__init__()
@@ -55,6 +56,7 @@ class Actor(nn.Module):
         self.with_feature3 = with_feature3
         self.with_simpleMDP = with_simpleMDP
         self.with_RTDL = with_RTDL
+        self.trainable_geo_weight = trainable_geo_weight
         self.use_1tree_opt = use_1tree_opt
         
         if problem_name == 'tsp':
@@ -91,7 +93,8 @@ class Actor(nn.Module):
                                     with_RNN = self.with_RNN,
                                     with_feature3 = self.with_feature3,
                                     simpleMDP = self.with_simpleMDP,
-                                    geo_weight = geo_weight
+                                    geo_weight = geo_weight,
+                                    trainable_geo_weight = self.trainable_geo_weight
                                     )
 
         print('# params in Actor', self.get_parameter_number())

--- a/nets/graph_layers.py
+++ b/nets/graph_layers.py
@@ -311,7 +311,8 @@ class kopt_Decoder(nn.Module):
             with_RNN = True,
             with_feature3 = True,
             simpleMDP = False,
-            geo_weight = 5.0
+            geo_weight = 5.0,
+            trainable_geo_weight = False
     ):
         super(kopt_Decoder, self).__init__()
         self.n_heads = n_heads
@@ -322,8 +323,10 @@ class kopt_Decoder(nn.Module):
         self.with_RNN = with_RNN
         self.with_feature3 = with_feature3
         self.simpleMDP = simpleMDP
-        # self.geo_weight = nn.Parameter(torch.tensor(float(geo_weight)))
-        self.geo_weight = torch.tensor(geo_weight)
+        if trainable_geo_weight:
+            self.geo_weight = nn.Parameter(torch.tensor(float(geo_weight)))
+        else:
+            self.register_buffer('geo_weight', torch.tensor(float(geo_weight)))
         print('simpleMDP: ', self.simpleMDP)
         assert simpleMDP
         

--- a/options.py
+++ b/options.py
@@ -77,6 +77,8 @@ def get_options(args=None):
                         help='Final value for geo_weight after annealing')
     parser.add_argument('--geo_weight_anneal_epochs', type=int, default=0,
                         help='Number of epochs over which to anneal geo_weight (0 disables annealing)')
+    parser.add_argument('--trainable_geo_weight', action='store_true',
+                        help='Enable training of decoder geo_weight parameter')
     
     ### logs to tensorboard and screen
     parser.add_argument('--no_progress_bar', action='store_true', help='Disable progress bar')


### PR DESCRIPTION
## Summary
- Add `trainable_geo_weight` flag so decoder's `geo_weight` can be trained or fixed
- Propagate flag through actor, PPO, and CLI options
- Document optional trainable `geo_weight`