### PR TITLE
Add optional trainable geo_weight parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ You can resume a training by adding the --resume option:
 ```
 The Tensorboard logs will be saved to folder "logs" and the trained model (checkpoint) will be saved to folder "outputs".
 Tensorboard now records the decoder's `geo_weight` as `train/geo_weight` for each mini-step.
+Use `--trainable_geo_weight` to make `geo_weight` a learnable parameter (annealing is disabled when this flag is set).
 
 ## Inference
 Load the model and specify the following hyper-parameters for inference:

--- a/agent/ppo.py
+++ b/agent/ppo.py
@@ -64,7 +64,8 @@ class PPO:
             with_RTDL = not opts.wo_RTDL,
             geo_weight = opts.geo_weight,
             use_1tree_opt = opts.use_1tree_opt,
-            normalize_curr_dist = not opts.no_curr_dist_norm
+            normalize_curr_dist = not opts.no_curr_dist_norm,
+            trainable_geo_weight = opts.trainable_geo_weight
         )
         
         if not opts.eval_only:
@@ -274,8 +275,8 @@ def train(rank, problem, agent, val_dataset, tb_logger):
 
         agent.lr_scheduler.step(epoch)
 
-        # Anneal geo_weight if configured
-        if opts.geo_weight_anneal_epochs > 0:
+        # Anneal geo_weight if configured and not trainable
+        if (not opts.trainable_geo_weight) and opts.geo_weight_anneal_epochs > 0:
             if epoch < opts.geo_weight_anneal_epochs:
                 if opts.geo_weight_anneal_epochs > 1:
                     ratio = epoch / (opts.geo_weight_anneal_epochs - 1)
@@ -285,7 +286,7 @@ def train(rank, problem, agent, val_dataset, tb_logger):
             else:
                 new_weight = opts.geo_weight_min
             decoder = agent.actor.module.decoder if hasattr(agent.actor, 'module') else agent.actor.decoder
-            decoder.geo_weight = torch.tensor(new_weight, device=decoder.geo_weight.device)
+            decoder.geo_weight.data.fill_(new_weight)
 
         # Training mode
         if rank == 0:

--- a/nets/actor_network.py
+++ b/nets/actor_network.py
@@ -38,7 +38,8 @@ class Actor(nn.Module):
                  with_RTDL,
                  geo_weight=5.0,
                  use_1tree_opt=False,
-                 normalize_curr_dist=True
+                 normalize_curr_dist=True,
+                 trainable_geo_weight=False
                  ):
         super(Actor, self).__init__()
 
@@ -58,6 +59,7 @@ class Actor(nn.Module):
         self.with_RTDL = with_RTDL
         self.use_1tree_opt = use_1tree_opt
         self.normalize_curr_dist = normalize_curr_dist
+        self.trainable_geo_weight = trainable_geo_weight
         
         if problem_name == 'tsp':
             self.node_dim = 2
@@ -94,7 +96,8 @@ class Actor(nn.Module):
                                     with_feature3 = self.with_feature3,
                                     simpleMDP = self.with_simpleMDP,
                                     geo_weight = geo_weight,
-                                    normalize_curr_dist = self.normalize_curr_dist
+                                    normalize_curr_dist = self.normalize_curr_dist,
+                                    trainable_geo_weight = self.trainable_geo_weight
                                     )
 
         print('# params in Actor', self.get_parameter_number())

--- a/nets/graph_layers.py
+++ b/nets/graph_layers.py
@@ -312,7 +312,8 @@ class kopt_Decoder(nn.Module):
             with_feature3 = True,
             simpleMDP = False,
             geo_weight = 5.0,
-            normalize_curr_dist = True
+            normalize_curr_dist = True,
+            trainable_geo_weight = False
     ):
         super(kopt_Decoder, self).__init__()
         self.n_heads = n_heads
@@ -324,8 +325,10 @@ class kopt_Decoder(nn.Module):
         self.with_feature3 = with_feature3
         self.simpleMDP = simpleMDP
         self.normalize_curr_dist = normalize_curr_dist
-        # self.geo_weight = nn.Parameter(torch.tensor(float(geo_weight)))
-        self.geo_weight = torch.tensor(geo_weight)
+        if trainable_geo_weight:
+            self.geo_weight = nn.Parameter(torch.tensor(float(geo_weight)))
+        else:
+            self.register_buffer('geo_weight', torch.tensor(geo_weight))
         print('simpleMDP: ', self.simpleMDP)
         assert simpleMDP
         

--- a/options.py
+++ b/options.py
@@ -77,6 +77,8 @@ def get_options(args=None):
                         help='Final value for geo_weight after annealing')
     parser.add_argument('--geo_weight_anneal_epochs', type=int, default=0,
                         help='Number of epochs over which to anneal geo_weight (0 disables annealing)')
+    parser.add_argument('--trainable_geo_weight', action='store_true',
+                        help='Make decoder geo_weight a learnable parameter and disable annealing')
     parser.add_argument('--no_curr_dist_norm', action='store_true',
                         help='Disable normalization of curr_dist before applying geo_weight')
     


### PR DESCRIPTION
## Summary
- add `--trainable_geo_weight` flag to make decoder geo_weight learnable
- expose trainable flag through Actor and Decoder, using nn.Parameter when enabled
- disable annealing when geo_weight is trainable and document new option